### PR TITLE
Fogl 4183

### DIFF
--- a/python/fledge/plugins/south/person_detection/inference.py
+++ b/python/fledge/plugins/south/person_detection/inference.py
@@ -30,8 +30,6 @@ except ImportError as e:
     _LOGGER.exception("Tensorflow installation not found.")
 
 
-
-
 class Inference:
     def __init__(self):
 

--- a/python/fledge/plugins/south/person_detection/person_detection.py
+++ b/python/fledge/plugins/south/person_detection/person_detection.py
@@ -236,7 +236,7 @@ def plugin_reconfigure(handle, new_config):
     parameters_to_check = ['camera_id', 'enable_window', 'enable_web_streaming', 'web_streaming_port_no']
     need_to_shutdown = check_need_to_shutdown(handle, new_config, parameters_to_check)
     if not need_to_shutdown:
-        _LOGGER.info("No need to shutdown")
+        _LOGGER.debug("No need to shutdown")
         frame_processor.handle_new_config(new_config)
         new_handle = plugin_init(new_config)
         return new_handle
@@ -302,7 +302,7 @@ def plugin_register_ingest(handle, callback, ingest_ref):
         callback: C opaque object required to passed back to C/Python async ingest interface
         ingest_ref: C opaque object required to passed back to C/Python async ingest interface
     """
-    _LOGGER.info("register ingest")
+    _LOGGER.debug("register ingest")
     global c_callback, c_ingest_ref
     c_callback = callback
     c_ingest_ref = ingest_ref
@@ -428,7 +428,7 @@ class FrameProcessor(Thread):
 
     def handle_new_config(self, new_config):
 
-        _LOGGER.info("Handling the reconfigure without shutdown")
+        _LOGGER.debug("Handling the reconfigure without shutdown")
         model = new_config['model_file']['value']
         labels = new_config['labels_file']['value']
         self.asset_name = new_config['asset_name']['value']
@@ -444,7 +444,7 @@ class FrameProcessor(Thread):
 
         _ = self.inference.get_interpreter(model, enable_tpu,
                                            labels, self.min_conf_threshold)
-        _LOGGER.info("Handled the reconfigure")
+        _LOGGER.debug("Handled the reconfigure")
 
     def run(self):
         # these variables are used for calculation of frame per seconds (FPS)
@@ -559,7 +559,7 @@ class FrameProcessor(Thread):
 
             # All the results have been drawn on the frame, so it's time to display it.
             if self.shutdown_in_progress:
-                _LOGGER.info("Shut down breaking loop")
+                _LOGGER.debug("Shut down breaking loop")
                 break
             else:
                 # Calculate framerate
@@ -573,7 +573,7 @@ class FrameProcessor(Thread):
                     'timestamp': utils.local_timestamp(),
                     'readings': reads
                 }
-                # _LOGGER.info("normal ingested readings")
+
                 async_ingest.ingest_callback(c_callback, c_ingest_ref, data)
 
                 # show the frame on the window
@@ -589,11 +589,11 @@ class FrameProcessor(Thread):
                 # wait for 1 milli second
                 cv2.waitKey(1)
 
-        _LOGGER.info("Stopping the stream ")
+        _LOGGER.debug("Stopping the stream ")
         self.videostream.stop()
         _LOGGER.info("Camera stream has been stopped")
         time.sleep(2)
         cv2.destroyAllWindows()
-        _LOGGER.info("All windows destroyed")
+        _LOGGER.debug("All windows destroyed")
         WebStream.SHUTDOWN_IN_PROGRESS = True
-        _LOGGER.info("Shutdown flag of streaming server set True")
+        _LOGGER.debug("Shutdown flag of streaming server set True")

--- a/python/fledge/plugins/south/person_detection/person_detection.py
+++ b/python/fledge/plugins/south/person_detection/person_detection.py
@@ -116,6 +116,11 @@ loop = None
 async_thread = None
 enable_web_streaming = None
 web_stream = None
+# Hard coding camera resolution for now. Can give it inside configuration. However changing
+# it is quite risky because some devices support changing camera resolution through opencv API
+# but others simply don't (Like the coral board).
+CAMERA_HEIGHT = 480
+CAMERA_WIDTH = 640
 
 
 def plugin_info():
@@ -168,8 +173,8 @@ def plugin_start(handle):
         # be (0+255)/2 = 127.5 .
         handle['input_mean'] = 127.5
         handle['input_std'] = 127.5
-        handle['camera_height'] = 640
-        handle['camera_width'] = 480
+        handle['camera_height'] = CAMERA_HEIGHT
+        handle['camera_width'] = CAMERA_WIDTH
 
         web_streaming_port_no = int(handle['web_streaming_port_no']['value'])
 
@@ -515,10 +520,10 @@ class FrameProcessor(Thread):
                     xmax_model = round(boxes[i][3], 3)
 
                     # map the bounding boxes from model to the window
-                    ymin = int(max(1, (ymin_model * self.camera_width)))
-                    xmin = int(max(1, (xmin_model * self.camera_height)))
-                    ymax = int(min(self.camera_width, (ymax_model * self.camera_width)))
-                    xmax = int(min(self.camera_height, (xmax_model * self.camera_height)))
+                    ymin = int(max(1, (ymin_model * self.camera_height)))
+                    xmin = int(max(1, (xmin_model * self.camera_width)))
+                    ymax = int(min(self.camera_height, (ymax_model * self.camera_height)))
+                    xmax = int(min(self.camera_width, (xmax_model * self.camera_width)))
 
                     # draw the rectangle on the frame
                     cv2.rectangle(frame, (xmin, ymin), (xmax, ymax), (10, 255, 0), 2)

--- a/python/fledge/plugins/south/person_detection/person_detection.py
+++ b/python/fledge/plugins/south/person_detection/person_detection.py
@@ -243,11 +243,21 @@ def plugin_reconfigure(handle, new_config):
         return new_handle
     
     else:
-        plugin_shutdown(handle)
-        new_handle = plugin_init(new_config)
-        plugin_start(new_handle)
 
-        return new_handle
+        was_native_window_enabled = handle['enable_window']['value'] == 'true'
+        is_native_window_enabled_now = new_config['enable_window']['value'] == 'true'
+
+        if was_native_window_enabled or is_native_window_enabled_now:
+            _LOGGER.warning("Enabling the native window during reconfigure is known to cause problems. "
+                            "Restart the plugin manually. ")
+            new_handle = plugin_init(new_config)
+            return new_handle
+
+        else:
+            plugin_shutdown(handle)
+            new_handle = plugin_init(new_config)
+            plugin_start(new_handle)
+            return new_handle
 
 
 def plugin_shutdown(handle):

--- a/python/fledge/plugins/south/person_detection/person_detection.py
+++ b/python/fledge/plugins/south/person_detection/person_detection.py
@@ -300,7 +300,11 @@ def plugin_shutdown(handle):
         # allow the stream to stop
         time.sleep(3)
         # stopping every other thread one by one
-        frame_processor.join()
+
+        # checking if the thread is started or not.
+        if frame_processor.is_camera_functional:
+            frame_processor.join()
+
         frame_processor = None
         if enable_web_streaming:
             WebStream.SHUTDOWN_IN_PROGRESS = True

--- a/python/fledge/plugins/south/person_detection/person_detection.py
+++ b/python/fledge/plugins/south/person_detection/person_detection.py
@@ -116,7 +116,7 @@ loop = None
 async_thread = None
 enable_web_streaming = None
 web_stream = None
-# Hard coding camera resolution for now. Can give it inside configuration. However changing
+# Keeping a fixed camera resolution for now. Can give it inside configuration. However changing
 # it is quite risky because some devices support changing camera resolution through opencv API
 # but others simply don't (Like the coral board).
 CAMERA_HEIGHT = 480

--- a/python/fledge/plugins/south/person_detection/person_detection.py
+++ b/python/fledge/plugins/south/person_detection/person_detection.py
@@ -208,23 +208,16 @@ def plugin_start(handle):
         _LOGGER.info("Plugin started")
 
 
-def check_need_to_shutdown(handle, new_config):
+def check_need_to_shutdown(handle, new_config, parameters_to_check):
 
-    old_camera_id = handle['camera_id']['value']
-    old_enable_window = handle['enable_window']['value']
-    old_enable_web_streaming = handle['enable_web_streaming']['value']
-    old_port_no = handle['web_streaming_port_no']['value']
+    shutdown = False
+    for parameter in parameters_to_check:
+        old_value = handle[parameter]['value']
+        new_value = new_config[parameter]['value']
+        if new_value != old_value:
+            shutdown = True
 
-    new_camera_id = new_config['camera_id']['value']
-    new_enable_window = new_config['enable_window']['value']
-    new_enable_web_streaming = new_config['enable_web_streaming']['value']
-    new_port_no = new_config['web_streaming_port_no']['value']
-
-    if old_camera_id != new_camera_id or old_enable_window != new_enable_window or \
-       old_enable_web_streaming != new_enable_web_streaming or old_port_no != new_port_no:
-        return True
-    else:
-        return False
+    return shutdown
 
 
 def plugin_reconfigure(handle, new_config):
@@ -240,7 +233,8 @@ def plugin_reconfigure(handle, new_config):
     """
     global frame_processor
 
-    need_to_shutdown = check_need_to_shutdown(handle, new_config)
+    parameters_to_check = ['camera_id', 'enable_window', 'enable_web_streaming', 'web_streaming_port_no']
+    need_to_shutdown = check_need_to_shutdown(handle, new_config, parameters_to_check)
     if not need_to_shutdown:
         _LOGGER.info("No need to shutdown")
         frame_processor.handle_new_config(new_config)

--- a/python/fledge/plugins/south/person_detection/person_detection.py
+++ b/python/fledge/plugins/south/person_detection/person_detection.py
@@ -209,15 +209,24 @@ def plugin_start(handle):
 
 
 def check_need_to_shutdown(handle, new_config, parameters_to_check):
+    """
+    Checks whether shutdown is required if we change configuration.
+    Args:
+        handle: Old configuration
+        new_config: New Configuration
+        parameters_to_check: Parameters (list) whose value if changed then shutdown is required
 
-    shutdown = False
+    Returns:
+        True or False
+    """
+    need_to_shutdown = False
     for parameter in parameters_to_check:
         old_value = handle[parameter]['value']
         new_value = new_config[parameter]['value']
         if new_value != old_value:
-            shutdown = True
+            need_to_shutdown = True
 
-    return shutdown
+    return need_to_shutdown
 
 
 def plugin_reconfigure(handle, new_config):
@@ -427,6 +436,14 @@ class FrameProcessor(Thread):
                 time.sleep(0.2)
 
     def handle_new_config(self, new_config):
+        """
+        If shutdown is not required then it changes the configuration on the fly.
+        Args:
+            new_config: The configuration during reconfigure.
+
+        Returns:
+              None
+        """
 
         _LOGGER.debug("Handling the reconfigure without shutdown")
         model = new_config['model_file']['value']

--- a/python/fledge/plugins/south/person_detection/videostream.py
+++ b/python/fledge/plugins/south/person_detection/videostream.py
@@ -55,6 +55,9 @@ class VideoStream:
             _ = self.stream.set(4, resolution[1])
         elif detectCoralDevBoard():
             self.stream = cv2.VideoCapture(source)
+        else:
+            # If the device is not supported self.stream would be None.
+            self.stream = cv2.VideoCapture(source)
 
         if self.stream is None:
             _LOGGER.exception("Either the ID of video device is wrong or the device is not supported")

--- a/python/fledge/plugins/south/person_detection/videostream.py
+++ b/python/fledge/plugins/south/person_detection/videostream.py
@@ -55,8 +55,11 @@ class VideoStream:
             _ = self.stream.set(4, resolution[1])
         elif detectCoralDevBoard():
             self.stream = cv2.VideoCapture(source)
+            # cannot change camera resolution on coral device through opencv API.
         else:
             # If the device is not supported self.stream would be None.
+            # There could be another format such as YUYV which may support changing camera resolution
+            # through Open CV API. Omitting these calls for now.
             self.stream = cv2.VideoCapture(source)
 
         if self.stream is None:

--- a/python/fledge/plugins/south/person_detection/videostream.py
+++ b/python/fledge/plugins/south/person_detection/videostream.py
@@ -63,7 +63,10 @@ class VideoStream:
             self.stream = cv2.VideoCapture(source)
 
         if self.stream is None:
-            _LOGGER.exception("Either the ID of video device is wrong or the device is not supported")
+            _LOGGER.exception("Either the ID of video device is wrong or the device is not supported. Please "
+                              "shut the plugin and try again with a correct device id.")
+        else:
+            _LOGGER.debug("Camera stream initialized")
 
         self.enable_thread = enable_thread
         if self.enable_thread:
@@ -78,8 +81,11 @@ class VideoStream:
         else:
             (self.grabbed, self.frame) = self.stream.read()
             if not self.grabbed:
-                _LOGGER.exception("Either the ID of video device is wrong or the device is not functional!")
+                _LOGGER.exception("The device is not functional!. Please shutdown the plugin and try again"
+                                  " with either a different camera ID or reconnect the device again. ")
                 return
+            else:
+                _LOGGER.debug("Able to capture video stream from camera.")
 
     def start(self):
         if self.enable_thread:
@@ -87,7 +93,7 @@ class VideoStream:
             t = Thread(target=self.update, args=(), name="Reader Thread")
             t.daemon = True
             t.start()
-        return self
+        return self, self.grabbed
 
     def update(self):
         # Keep looping indefinitely until the thread is stopped

--- a/python/fledge/plugins/south/person_detection/web_stream.py
+++ b/python/fledge/plugins/south/person_detection/web_stream.py
@@ -33,16 +33,18 @@ class WebStream:
                             'boundary=--%s' % boundary,
         })
         await response.prepare(request)
-
         encode_param = (int(cv2.IMWRITE_JPEG_QUALITY), 90)
 
         while True:
+
             if WebStream.SHUTDOWN_IN_PROGRESS:
                 break
+
             if WebStream.FRAME is None:
                 continue
 
             result, encimg = cv2.imencode('.jpg', WebStream.FRAME, encode_param)
+
             data = encimg.tostring()
             await response.write(
                 '--{}\r\n'.format(boundary).encode('utf-8'))
@@ -72,6 +74,7 @@ class WebStream:
             asyncio.ensure_future(self.ws_app.shutdown(), loop=loop)
             asyncio.ensure_future(self.ws_handler.shutdown(2.0), loop=loop)
             asyncio.ensure_future(self.ws_app.cleanup(), loop=loop)
+
         except asyncio.CancelledError:
             pass
         except KeyError:
@@ -90,12 +93,14 @@ class WebStream:
                     self
                Raises: None
         """
-
         app = web.Application(loop=local_loop)
         app.router.add_route('GET', "/", WebStream.index)
         app.router.add_route('GET', "/image", WebStream.mjpeg_handler)
+
         handler = app.make_handler(loop=local_loop)
+
         coro_server = local_loop.create_server(handler, self.address, self.port)
+
         f = asyncio.ensure_future(coro_server, loop=local_loop)
 
         self.ws_app = app
@@ -107,6 +112,5 @@ class WebStream:
             self.ws_server = f.result()
 
         f.add_done_callback(f_callback)
+
         return self
-
-


### PR DESCRIPTION
1. We only need to shutdown camera stream when stream from different camera has to be shown or the stream has to be shown on a different port on the stream server. 

2. Enable / Disable the native window during reconfigure is causing problems because Open CV gui display should not be kept in other thread than main. Here is the [issue](https://stackoverflow.com/questions/60737852/opencv-imshow-hangs-if-called-two-times-from-a-thread) that discusses this. 

3. Capture stream from other cameras as well , Handled the case if stream did not arrive.  

4. Addressed the issue when wrong device ID is given and plugin could not start again even after shut down. 