### PR TITLE
FOGL-4795

### DIFF
--- a/extras_install.sh
+++ b/extras_install.sh
@@ -31,7 +31,7 @@ fi
 
 py=$(python3 -V | awk '{print $2}' | awk -F. '{print $1 $2}')
 arch=$(uname -m)
-url=$(echo -n "https://dl.google.com/coral/python/tflite_runtime-2.1.0.post1-cp"; echo -n $py; echo -n "-cp"; echo -n $py; echo -n "m-linux_"; echo -n ${arch}; echo -n ".whl")
+url=$(echo -n "https://github.com/google-coral/pycoral/releases/download/release-frogfish/tflite_runtime-2.5.0-cp"; echo -n $py; echo -n "-cp"; echo -n $py; echo -n "m-linux_"; echo -n ${arch}; echo -n ".whl")
 pip3 install $url
 
 if [ ${ID} != "mendel" ]; then

--- a/install_notes.txt
+++ b/install_notes.txt
@@ -1,0 +1,13 @@
+In order to use Edge TPU accelerator on devices other than coral board then you might
+need to follow the steps given below.
+
+1. echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list
+
+2. curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+
+3. sudo apt-get update
+
+4. sudo apt-get install libedgetpu1-std
+ or sudo apt-get install libedgetpu1-max depending on performance.
+
+For more details refer to https://coral.ai/docs/accelerator/get-started/#1a-on-linux


### PR DESCRIPTION
The tflite library will now be part of pycoral library. So now tflite has to updated for latest version as of now 2.5.0 and latest pycoral version frogfish. The plugin will work on raspberry pi and ubuntu 18. However on the coral dev board upgrade to new Mendel OS Eagle will cause errors. 

Please note that  while upgrading the tflite libray if you want to use Edge TPU along with it then you also need to upgrade the run time for Edge TPU even if you have installed the Edge TPU runtime. For  more details to upgrade refer [here](https://coral.ai/docs/accelerator/get-started/#1a-on-linux) 